### PR TITLE
Don't mark messages as seen when fetching from mailbox

### DIFF
--- a/mmuxer/cli/folder.py
+++ b/mmuxer/cli/folder.py
@@ -97,5 +97,5 @@ def move_emails(source_folder: str, dest_folder: str):
 
     box = state.mailbox
     box.folder.set(source_folder)
-    for msg in box.fetch(bulk=100):
+    for msg in box.fetch(bulk=100, mark_seen=False):
         box.move(msg.uid, dest_folder)

--- a/mmuxer/cli/run.py
+++ b/mmuxer/cli/run.py
@@ -20,7 +20,7 @@ def _tidy(
     if folder is not None:
         box.folder.set(folder)
     counter = 0
-    for msg in box.fetch(bulk=100):
+    for msg in box.fetch(bulk=100, mark_seen=False):
         msg.associated_folder = folder
         apply_list(state.rules, box, msg, dry_run)
         for script in state.scripts:


### PR DESCRIPTION
Don't mark messages as seen when fetching them from the mailbox.

For https://github.com/sapristi/mmuxer/issues/6.