### PR TITLE
FileNotFoundError fix

### DIFF
--- a/mmuxer/models/settings.py
+++ b/mmuxer/models/settings.py
@@ -7,9 +7,12 @@ from mmuxer.models.common import BaseModel
 
 def in_container():
     """Returns: True iff running in a container"""
-    with open("/proc/1/cgroup") as ifh:
-        value = ifh.read()
-        return "docker" in value or "kubepod" in value
+    try:
+        with open("/proc/1/cgroup") as ifh:
+            value = ifh.read()
+            return "docker" in value or "kubepod" in value
+    except:
+        return False
 
 
 class Settings(BaseModel, BaseSettings):


### PR DESCRIPTION
When running under Windows, the current version fails with: FileNotFoundError: [Errno 2] No such file or directory: '/proc/1/cgroup'

Added a try ... except to return false instead of failing.