### PR TITLE
Filter based on from name

### DIFF
--- a/mmuxer/models/condition.py
+++ b/mmuxer/models/condition.py
@@ -66,6 +66,17 @@ class From(IBaseCondition):
     def __rich_repr__(self):
         yield self.operator.name, self.FROM
 
+class Name(IBaseCondition):
+    NAME: Union[str, frozenset[str]]
+
+    def get_value(self, message: MailMessage):
+        return message.from_values.name
+
+    def get_operand(self) -> Union[str, Sequence[str]]:
+        return self.NAME
+
+    def __rich_repr__(self):
+        yield self.operator.name, self.NAME
 
 class To(IBaseCondition):
     TO: Union[str, frozenset[str]]
@@ -110,7 +121,7 @@ class Body(IBaseCondition):
         return f'body :text {self.operator.sieve} "{self.get_operand()}'
 
 
-BaseCondition = Union[From, To, Subject, Body]
+BaseCondition = Union[From, Name, To, Subject, Body]
 
 
 def is_base_condition(obj):

--- a/mmuxer/models/condition.py
+++ b/mmuxer/models/condition.py
@@ -58,25 +58,14 @@ class From(IBaseCondition):
     FROM: Union[str, frozenset[str]]
 
     def get_value(self, message: MailMessage):
-        return message.from_
+        # Remove trailing spaces if name of address is empty, returning one of 1) "name <name@example.com>" 2) "<name@example.com>" 3) "name".
+        return f"{message.from_values.name} <{message.from_}>".strip(' ')
 
     def get_operand(self) -> Union[str, Sequence[str]]:
         return self.FROM
 
     def __rich_repr__(self):
         yield self.operator.name, self.FROM
-
-class Name(IBaseCondition):
-    NAME: Union[str, frozenset[str]]
-
-    def get_value(self, message: MailMessage):
-        return message.from_values.name
-
-    def get_operand(self) -> Union[str, Sequence[str]]:
-        return self.NAME
-
-    def __rich_repr__(self):
-        yield self.operator.name, self.NAME
 
 class To(IBaseCondition):
     TO: Union[str, frozenset[str]]
@@ -121,7 +110,7 @@ class Body(IBaseCondition):
         return f'body :text {self.operator.sieve} "{self.get_operand()}'
 
 
-BaseCondition = Union[From, Name, To, Subject, Body]
+BaseCondition = Union[From, To, Subject, Body]
 
 
 def is_base_condition(obj):


### PR DESCRIPTION
I added the option to filter emails based on from name. I named the attribute `NAME` but perhaps a better name would be `FROMNAME`, `FROM_NAME` or `CORRESPONDENT`