### PR TITLE
Specify UTF-8 when reading files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ If you get SSL errors while connecting to your server, see the [SSL Configuratio
       name: str | None = None  # name used when exporting with managesieve
       extensions: list[str] = ["fileinto"]
 
+## Encoding
+
+Reading a file in python default to whatever [locale.getencoding()](https://docs.python.org/3/library/locale.html#locale.getencoding) returns.
+If you need to parse your config file in a different encoding,  specify this 
+with the `--encoding` parameter:
+
+       mmuxer tidy --config-file config.yaml --encoding uft-8
+
+See the [documentation](https://docs.python.org/3/library/codecs.html#standard-encodings)
+for a full list of all supported encodings.
+
 ## Going further on
 
 - [Advanced usage](./docs/advanced_usage.md)

--- a/mmuxer/__main__.py
+++ b/mmuxer/__main__.py
@@ -75,8 +75,9 @@ app.command(rich_help_panel="Main commands", hidden=True)(purge_cmd)
 
 
 @app.command(rich_help_panel="Util commands")
-def check(config_file: Path = config_file_typer_option):
+def check(config_file: Path = config_file_typer_option, encoding: str = None):
     """Load the config and connect to the IMAP server."""
+    state.encoding = encoding
     state.load_config_file(config_file)
     state.create_mailbox()
     pprint(state.rules)

--- a/mmuxer/cli/run.py
+++ b/mmuxer/cli/run.py
@@ -43,8 +43,10 @@ def tidy(
     config_file: Path = config_file_typer_option,
     folder: Union[str, None] = typer.Option(None, help="Folder to fetch the messages from"),
     dry_run: bool = typer.Option(False, help="Print actions instead of running them"),
+    encoding: str = typer.Option(None, help="Encoding to use when parsing config file"),
 ):
     """Run once, on all messages of the INBOX (or the given folder)."""
+    state.encoding = encoding
     state.load_config_file(config_file)
     state.create_mailbox()
     _tidy(folder, dry_run)
@@ -57,8 +59,10 @@ def monitor(
     auto_reload: bool = typer.Option(
         False, help="Auto-reload config file on modification (EXPERIMENTAL)"
     ),
+    encoding: str = typer.Option(None, help="Encoding to use when parsing config file"),
 ):
     """Monitor mailbox, and apply rules on unseen messages."""
+    state.encoding = encoding
     state.load_config_file(config_file)
     state.create_mailbox()
 

--- a/mmuxer/config_state.py
+++ b/mmuxer/config_state.py
@@ -40,6 +40,7 @@ default_actions = {
 
 class State:
     __slots__ = (
+        "_encoding",
         "_settings",
         "_rules",
         "_scripts",
@@ -50,6 +51,7 @@ class State:
     )
 
     def __init__(self):
+        self._encoding = None
         self._settings = None
         self._rules = None
         self._scripts = None
@@ -83,7 +85,7 @@ class State:
         logger.info(f"Connected to {self.settings.server} with {self.settings.username}")
 
     def _parse_config_file(self):
-        config_raw = self.config_file.read_text()
+        config_raw = self.config_file.read_text(encoding=self._encoding)
         try:
             config_dict = yaml.safe_load(config_raw)
         except Exception:
@@ -149,6 +151,14 @@ class State:
         if self._config_file is None:
             raise Exception("Uninitialized config_file")
         return self._config_file
+
+    @property
+    def encoding(self) -> str:
+        return self.encoding
+
+    @encoding.setter
+    def encoding(self, value: str) -> None:
+        self._encoding = value
 
     @property
     def settings(self) -> Settings:


### PR DESCRIPTION
Rules with special characters (i.e. `å` ,`ä`, `ö` etc) were not parsed correctly because the encoding used was wrong when not set. 

Example:
`Ett ljud spelades upp på iphone` became `Ett ljud spelades upp pÃ¥ iphone`